### PR TITLE
Create fresh store on every request.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const wrapWithProvider = (createStore, PageComponent, cache) => class extends Co
   static async getInitialProps (ctx) {
     const {req} = ctx
     const isServer = !!req
-    if (!cache.store) {
+    if (!cache.store || isServer) {
       cache.store = createStore()
     }
     ctx.store = cache.store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-connect-redux",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Connect next.js to redux",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
We encountered the same bug mentioned in issue #6.  Testing isServer and creating a new store if true, should fix this issue.